### PR TITLE
Motor with different pins

### DIFF
--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -27,9 +27,10 @@
 
 
 CheapStepper::CheapStepper () {
-    
-	
-    
+    for (int pin=0; pin<4; pin++){
+        pinMode(pins[pin], OUTPUT);
+        Serial.print(pins[pin]);
+    }
 }
 
 CheapStepper::CheapStepper (int in1, int in2, int in3, int in4) {
@@ -42,10 +43,7 @@ CheapStepper::CheapStepper (int in1, int in2, int in3, int in4) {
     for (int pin=0; pin<4; pin++){
         pinMode(pins[pin], OUTPUT);
         Serial.print(pins[pin]);
-        
     }
-    
-	CheapStepper();
 }
 
 void CheapStepper::setRpm (int rpm){

--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -27,17 +27,24 @@
 
 
 CheapStepper::CheapStepper () {
-	for (int pin=0; pin<4; pin++){
-		pinMode(pins[pin], OUTPUT);
-	}
+    
+	
+    
 }
 
 CheapStepper::CheapStepper (int in1, int in2, int in3, int in4) {
-
+    
 	pins[0] = in1;
 	pins[1] = in2;
 	pins[2] = in3;
 	pins[3] = in4;
+    
+    for (int pin=0; pin<4; pin++){
+        pinMode(pins[pin], OUTPUT);
+        Serial.print(pins[pin]);
+        
+    }
+    
 	CheapStepper();
 }
 


### PR DESCRIPTION
I noticed that the 28byj stepper motor connected on different pins rather than the standard ones {8,9,10,11}, wasn't working. 

I noticed that the call from the constructor CheapStepper::CheapStepper (int in1, int in2, int in3, int in4) to the constructor CheapStepper::CheapStepper () was the problem. 

To quickly fix the problem I copied the content of the second constructor in the first and remove the call between constructors.