### PR TITLE
Fix the constructor

### DIFF
--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -26,19 +26,12 @@
 #include "CheapStepper.h"
 
 
-CheapStepper::CheapStepper () {
+CheapStepper::CheapStepper (int in1, int in2, int in3, int in4) : pins{in1, in2, in3, in4} {
 	for (int pin=0; pin<4; pin++){
-		pinMode(pins[pin], OUTPUT);
+		int setpin = pins[pin];
+		Serial.println("set pin: " + String(setpin));
+		pinMode(setpin, OUTPUT);
 	}
-}
-
-CheapStepper::CheapStepper (int in1, int in2, int in3, int in4) {
-
-	pins[0] = in1;
-	pins[1] = in2;
-	pins[2] = in3;
-	pins[3] = in4;
-	CheapStepper();
 }
 
 void CheapStepper::setRpm (int rpm){


### PR DESCRIPTION
When using different pins from the default they will not get set with the previous constructor arrangement.
The default pins are used regardless, which leads to crashes on ESP8266 since they are invalid pin numbers there.