### PR TITLE
seq method updated to save memory

### DIFF
--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -209,89 +209,16 @@ void CheapStepper::seqCCW (){
 	}
 }
 
-void CheapStepper::seq (int seqNum){
+void CheapStepper::seq (byte seqNum){
 
-	int pattern[4];
 	// A,B,C,D HIGH/LOW pattern to write to driver board
+	byte pattern[] = {0b1000, 0b1100, 0b0100, 0b0110, 0b0010, 0b0011, 0b0001, 0b1001, 0b0000};
 	
-	switch(seqNum){
-		case 0:
-		{
-			pattern[0] = 1;
-			pattern[1] = 0;
-			pattern[2] = 0;
-			pattern[3] = 0;
-			break;
-		}
-		case 1:
-		{
-			pattern[0] = 1;
-			pattern[1] = 1;
-			pattern[2] = 0;
-			pattern[3] = 0;
-			break;
-		}
-		case 2:
-		{
-			pattern[0] = 0;
-			pattern[1] = 1;
-			pattern[2] = 0;
-			pattern[3] = 0;
-			break;
-		}
-		case 3:
-		{
-			pattern[0] = 0;
-			pattern[1] = 1;
-			pattern[2] = 1;
-			pattern[3] = 0;
-			break;
-		}	
-		case 4:
-		{
-			pattern[0] = 0;
-			pattern[1] = 0;
-			pattern[2] = 1;
-			pattern[3] = 0;
-			break;
-		}
-		case 5:
-		{
-			pattern[0] = 0;
-			pattern[1] = 0;
-			pattern[2] = 1;
-			pattern[3] = 1;
-			break;
-		}
-		case 6:
-		{
-			pattern[0] = 0;
-			pattern[1] = 0;
-			pattern[2] = 0;
-			pattern[3] = 1;
-			break;
-		}
-		case 7:
-		{
-			pattern[0] = 1;
-			pattern[1] = 0;
-			pattern[2] = 0;
-			pattern[3] = 1;
-			break;
-		}
-		default:
-		{
-			pattern[0] = 0;
-			pattern[1] = 0;
-			pattern[2] = 0;
-			pattern[3] = 0;
-			break;
-		}
-	}
+	if(seqNum < 0 || seqNum > 8) seqNum = 8;
 
 	// write pattern to pins
 	for (int p=0; p<4; p++){
-		digitalWrite(pins[p], pattern[p]);
+		digitalWrite(pins[p], (pattern & (1 << 3-p)) >> 3-p);
 	}
 	delayMicroseconds(delay);
 }

--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -211,10 +211,56 @@ void CheapStepper::seqCCW (){
 
 void CheapStepper::seq (byte seqNum){
 
+	byte pattern;
 	// A,B,C,D HIGH/LOW pattern to write to driver board
-	byte pattern[] = {0b1000, 0b1100, 0b0100, 0b0110, 0b0010, 0b0011, 0b0001, 0b1001, 0b0000};
-	
-	if(seqNum < 0 || seqNum > 8) seqNum = 8;
+
+	switch (seqNum) {
+		case 0:
+		{
+			pattern = 0b1000;
+			break;
+		}
+		case 1:
+		{
+			pattern = 0b1100;
+			break;
+		}
+		case 2:
+		{
+			pattern = 0b0100;
+			break;
+		}
+		case 3:
+		{
+			pattern = 0b0110;
+			break;
+		}
+		case 4:
+		{
+			pattern = 0b0010;
+			break;
+		}
+		case 5:
+		{
+			pattern = 0b0011;
+			break;
+		}
+		case 6:
+		{
+			pattern = 0b0001;
+			break;
+		}
+		case 7:
+		{
+			pattern = 0b1001;
+			break;
+		}
+		default:
+		{
+			pattern = 0b000;
+			break;
+		}
+	}
 
 	// write pattern to pins
 	for (int p=0; p<4; p++){
@@ -222,5 +268,3 @@ void CheapStepper::seq (byte seqNum){
 	}
 	delayMicroseconds(delay);
 }
-
-

--- a/CheapStepper.h
+++ b/CheapStepper.h
@@ -105,7 +105,7 @@ private:
 
 	void seqCW();
 	void seqCCW();
-	void seq(int seqNum); // send specific sequence num to driver
+	void seq(byte seqNum); // send specific sequence num to driver
 
 	int pins[4]; // defaults to pins {8,9,10,11} (in1,in2,in3,in4 on the driver board)
 
@@ -118,7 +118,7 @@ private:
 	// low speed (high torque) = 1465 ~= 1 rpm
 	// high speed (low torque) = 600 ~=  24 rpm
 
-	int seqN = -1; // keeps track of sequence number
+	byte seqN = -1; // keeps track of sequence number
 
 	// variables for non-blocking moves:
 	unsigned long lastStepTime; // time in microseconds that last step happened


### PR DESCRIPTION
Principally I rewrote seq function in order to use only one byte of memory instead of 4 int.