### PR TITLE
Make non-blocking moves actually non-blocking and fix rpm

### DIFF
--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -136,10 +136,10 @@ void CheapStepper::run(){
 
 	if (micros() - lastStepTime >= delay) { // if time for step
 		if (stepsLeft > 0) { // clockwise
-			stepCW();
+			stepCW(false);
 			stepsLeft--;
 		} else if (stepsLeft < 0){ // counter-clockwise
-			stepCCW();
+			stepCCW(false);
 			stepsLeft++;
 		} 
 
@@ -153,10 +153,13 @@ void CheapStepper::stop(){
 }
 
 
-void CheapStepper::step(bool clockwise){
+void CheapStepper::step(bool clockwise, bool block){
 
 	if (clockwise) seqCW();
 	else seqCCW();
+	if(block) {
+		delayMicroseconds(delay);
+	}
 }
 
 void CheapStepper::off() {
@@ -293,7 +296,6 @@ void CheapStepper::seq (int seqNum){
 	for (int p=0; p<4; p++){
 		digitalWrite(pins[p], pattern[p]);
 	}
-	delayMicroseconds(delay);
 }
 
 

--- a/CheapStepper.h
+++ b/CheapStepper.h
@@ -80,11 +80,11 @@ public:
 
 
 
-	void step (bool clockwise);
+	void step (bool clockwise, bool block = true);
 	// move 1 step clockwise or counter-clockwise
 
-	void stepCW () { step (true); } // move 1 step clockwise
-	void stepCCW () { step (false); } // move 1 step counter-clockwise
+	void stepCW (bool block = true) { step (true, block); } // move 1 step clockwise
+	void stepCCW (bool block = true) { step (false, block); } // move 1 step counter-clockwise
 
 	int getStep() { return stepN; } // returns current miniStep position
 	int getDelay() { return delay; } // returns current delay (microseconds)


### PR DESCRIPTION
By having the delay in the `seq` function we also get a delay when calling the `run` method. Since we waited for `delay`µs , and then set `lastStepTime` the rpm was also halved.

This adds a "blocking" parameter to the step methods with the default set to true to retain the old behaviour 