### PR TITLE
Fix restarts on ESP devices

### DIFF
--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -25,6 +25,11 @@
 #include "Arduino.h"
 #include "CheapStepper.h"
 
+#if defined(ESP8266) || defined(ARDUINO_ESP8266_NODEMCU)
+	#define YIELD_TIME 1000 // Source https://www.sigmdel.ca/michel/program/esp8266/arduino/watchdogs_en.html#ESP8266_WDT_TIMEOUT
+#else
+	#define YIELD_TIME (0UL - 1UL) // Large number to only call it rarely
+#endif
 
 CheapStepper::CheapStepper () : pins({8,9,10,11}) {
 	for (int pin=0; pin<4; pin++){
@@ -158,11 +163,10 @@ void CheapStepper::step(bool clockwise){
 	if (clockwise) seqCW();
 	else seqCCW();
 
-	#if defined(ESP8266) || defined(ARDUINO_ESP8266_NODEMCU)
-		// return control to the system between the steps so that long series of those
-		// doesn't trigger watch dog restart on ESP
+	// return control to the system between the steps so that long series of those
+	// doesn't trigger watch dog restart on ESP
+	if (millis() - lastYieldTime >= YIELD_TIME) 
 		yield();
-	#endif
 }
 
 void CheapStepper::off() {

--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -166,7 +166,10 @@ void CheapStepper::step(bool clockwise){
 	// return control to the system between the steps so that long series of those
 	// doesn't trigger watch dog restart on ESP
 	if (millis() - lastYieldTime >= YIELD_TIME) 
+	{
 		yield();
+		lastYieldTime = millis();
+	}
 }
 
 void CheapStepper::off() {

--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -162,6 +162,11 @@ void CheapStepper::step(bool clockwise){
 void CheapStepper::off() {
 	for (int p=0; p<4; p++)
 		digitalWrite(pins[p], 0);
+	#if defined(ESP8266) || defined(ARDUINO_ESP8266_NODEMCU)
+		// return control to the system between the steps so that long series of those
+		// doesn't trigger watch dog restart on ESP
+		yield();
+	#endif
 }
 
 

--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -157,16 +157,17 @@ void CheapStepper::step(bool clockwise){
 
 	if (clockwise) seqCW();
 	else seqCCW();
-}
 
-void CheapStepper::off() {
-	for (int p=0; p<4; p++)
-		digitalWrite(pins[p], 0);
 	#if defined(ESP8266) || defined(ARDUINO_ESP8266_NODEMCU)
 		// return control to the system between the steps so that long series of those
 		// doesn't trigger watch dog restart on ESP
 		yield();
 	#endif
+}
+
+void CheapStepper::off() {
+	for (int p=0; p<4; p++)
+		digitalWrite(pins[p], 0);
 }
 
 


### PR DESCRIPTION
Addressing #3 

The restarts only happen on ESP devices and in case a long rotation is requested. The rotation is done by invocation of ```step()``` function in a loop, which ultimately does pin setup and ```delayMicroseconds```. The latter one doesn't return the control back to the system (unlike ```delay()```) sp the entire rotation happens in one solid execution. This is not a problem for an AVR, however on ESP (which has a network stack running in background) long runs without returning control back to the system cause watch dog to kick in and do a soft reset of the device.

In order to prevent such behavior, this PR adds invocation of ```yield()``` between performin the motor steps (gives a quick control back to the system).

The motor worked 360 degrees CW and CCW without restart with this change. The rotation speed visually wasn't affected. Returning control to the system is required for a reason, so perhaps there might be situations when the system actually starts doing some work and it will affect the motor performance, but it might be a matter for a bigger change. So far this PR should provide a reasonable relief, so that the library can be used on ESP devices