### PR TITLE
Add an option to ignore limits with a define

### DIFF
--- a/CheapStepper.cpp
+++ b/CheapStepper.cpp
@@ -170,9 +170,10 @@ void CheapStepper::off() {
 /////////////
 
 int CheapStepper::calcDelay (int rpm){
-
+	#ifndef IGNORE_LIMITS
 	if (rpm < 6) return delay; // will overheat, no change
 	else if (rpm >= 24) return 600; // highest speed
+	#endif
 
 	unsigned long d = 60000000 / (totalSteps* (unsigned long) rpm);
 	// in range: 600-1465 microseconds (24-1 rpm)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=CheapStepper
-version=0.2.1
+version=0.2.2
 author=Tyler Henry
 maintainer=Tyler Henry <tyler@tylerhenry.com>
 sentence=A library for the cheap but useful 28BYJ-48 5v stepper motor with ULN2003 driver board


### PR DESCRIPTION
In cases where running the motor at reduced current (12v motor on 5v) it'd be nice to be able to rotate reeeal slow. 